### PR TITLE
fix(order): 兼容接单/拒单 id 字段以修复 id 为 null 的问题

### DIFF
--- a/sky-pojo/src/main/java/com/sky/dto/OrdersConfirmDTO.java
+++ b/sky-pojo/src/main/java/com/sky/dto/OrdersConfirmDTO.java
@@ -1,11 +1,13 @@
 package com.sky.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 
 import java.io.Serializable;
 
 @Data
 public class OrdersConfirmDTO implements Serializable {
+    @JsonAlias({"orderId", "ordersId"})
     private Long id;
     //订单状态 1待付款 2待接单 3 已接单 4 派送中 5 已完成 6 已取消 7 退款
     private Integer status;

--- a/sky-pojo/src/main/java/com/sky/dto/OrdersRejectionDTO.java
+++ b/sky-pojo/src/main/java/com/sky/dto/OrdersRejectionDTO.java
@@ -1,5 +1,6 @@
 package com.sky.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -8,6 +9,7 @@ import java.io.Serializable;
 public class OrdersRejectionDTO implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    @JsonAlias({"orderId", "ordersId"})
     private Long id;
     private String rejectionReason;
     private Integer status;

--- a/sky-server/src/main/java/com/sky/service/impl/OrderServiceImpl.java
+++ b/sky-server/src/main/java/com/sky/service/impl/OrderServiceImpl.java
@@ -248,10 +248,14 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public void reject(OrdersRejectionDTO ordersRejectionDTO) {
+        if (ordersRejectionDTO.getId() == null) {
+            throw new OrderBusinessException("id为null");
+        }
+
         Orders order = orderMapper.getById(ordersRejectionDTO.getId());
         // 订单只有存在且状态为2（待接单）才可以拒单
         if (order == null || !order.getStatus().equals(Orders.TO_BE_CONFIRMED)) {
-            log.info("{} {}", order, order.getStatus());
+            log.info("拒单状态校验失败, order: {}", order);
             throw new OrderBusinessException("订单状态错误");
         }
         Integer payStatus = order.getPayStatus();


### PR DESCRIPTION
### Motivation
- 修复工作台接单/拒单接口在历史前端字段名差异下后端收到 `id == null` 导致无法接单或拒单的长期 bug。

### Description
- 为 `OrdersConfirmDTO.id` 和 `OrdersRejectionDTO.id` 增加 `@JsonAlias({"orderId","ordersId"})` 以兼容前端不同字段名，并在 `OrderServiceImpl.reject` 中补充 `id` 为空校验与改进日志以避免空指针。

### Testing
- 尝试运行构建检查命令 `mvn -q -pl sky-server -am test -DskipTests`，因运行环境无法访问 Maven 中央仓库（`repo.maven.apache.org` 返回 403）导致构建失败，自动化测试未能在此环境完成；代码变更已本地提交。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfab5046dc832cbf71a364fbb6a02d)